### PR TITLE
Remove stray comma

### DIFF
--- a/extract/extract.py
+++ b/extract/extract.py
@@ -845,6 +845,6 @@ if __name__ == '__main__':
         extract_bbox_clusters=extract_bbox_clusters,
         extract_semantic_segmentations=extract_semantic_segmentations,
         extract_crf_segmentations=extract_crf_segmentations,
-        extract_single_region_segmentations=extract_single_region_segmentations, , 
+        extract_single_region_segmentations=extract_single_region_segmentations,
         vis_segmentations=vis_segmentations,
     ))


### PR DESCRIPTION
There was a stray comma in `extract/extract.py`. Probably just a typo. Seems to work fine otherwise.