### PR TITLE
Add a line to retransform output image

### DIFF
--- a/extract/extract.py
+++ b/extract/extract.py
@@ -690,6 +690,7 @@ def _extract_crf_segmentations(
     segmap_crf = denseCRF.densecrf(image, unary_potentials, crf_params)  # (H_pad, W_pad)
 
     # Save
+    segmap_crf = segmap_crf.astype(np.uint8)*255 
     Image.fromarray(segmap_crf).convert('L').save(output_file)
 
 


### PR DESCRIPTION
Hello!


While running your code on my dataset, I noticed your CRF output was not being displayed correctly. I realised that this was an error between line 688 and 694. You were computing the correct CRF, however, since it was a binary array generated you need to multiply it by 255 to have the appropriate image pixel values generated. Convert('L') does not seem to be having a desired effect on MacOS and Linux with an Nvidia A5000 (the bases on which I have tested your code). I hope this addition is valuable to your code and subsequent research.

Best,
Aakash